### PR TITLE
Make TradeMessage sentinel fields optional

### DIFF
--- a/src/message.rs
+++ b/src/message.rs
@@ -267,15 +267,15 @@ pub struct TradeMessage {
     date: String,
     nanoseconds: u64,
     kind: char, // P = non-cross, Q = cross, B = broken
-    refno: u64,
-    side: Side, /* The type of non-display order on the book being matched (always "B" effective
-                 * 07/14/2014) */
-    shares: u64,
-    ticker: String,
-    price: u32,
+    refno: Option<u64>,
+    side: Option<Side>, /* The type of non-display order on the book being matched (always "B"
+                         * effective 07/14/2014) */
+    shares: Option<u64>,
+    ticker: Option<String>,
+    price: Option<u32>,
     matchno: u64,
-    cross_price: u32,
-    cross_type: char,
+    cross_price: Option<u32>,
+    cross_type: Option<char>,
 }
 
 pub trait IntoTradeMessage {
@@ -397,6 +397,71 @@ mod tests {
         };
         context.active_orders.insert(1, order);
         assert!(context.has_order(1));
+    }
+
+    fn serialize_trade_message_to_csv(msg: &TradeMessage) -> String {
+        let mut wtr = csv::WriterBuilder::new()
+            .has_headers(false)
+            .from_writer(vec![]);
+        wtr.serialize(msg).unwrap();
+        String::from_utf8(wtr.into_inner().unwrap()).unwrap()
+    }
+
+    #[test]
+    fn trade_message_csv_serializes_non_cross() {
+        let msg = TradeMessage {
+            date: "2024-01-15".to_string(),
+            nanoseconds: 123,
+            kind: 'P',
+            refno: Some(42),
+            side: Some(Side::Buy),
+            shares: Some(100),
+            ticker: Some("AAPL".to_string()),
+            price: Some(1500000),
+            matchno: 7,
+            cross_price: None,
+            cross_type: None,
+        };
+        let csv = serialize_trade_message_to_csv(&msg);
+        assert_eq!(csv, "2024-01-15,123,P,42,B,100,AAPL,1500000,7,,\n");
+    }
+
+    #[test]
+    fn trade_message_csv_serializes_cross() {
+        let msg = TradeMessage {
+            date: "2024-01-15".to_string(),
+            nanoseconds: 123,
+            kind: 'Q',
+            refno: None,
+            side: None,
+            shares: Some(500),
+            ticker: Some("AAPL".to_string()),
+            price: None,
+            matchno: 7,
+            cross_price: Some(1500000),
+            cross_type: Some('O'),
+        };
+        let csv = serialize_trade_message_to_csv(&msg);
+        assert_eq!(csv, "2024-01-15,123,Q,,,500,AAPL,,7,1500000,O\n");
+    }
+
+    #[test]
+    fn trade_message_csv_serializes_broken() {
+        let msg = TradeMessage {
+            date: "2024-01-15".to_string(),
+            nanoseconds: 123,
+            kind: 'B',
+            refno: None,
+            side: None,
+            shares: None,
+            ticker: None,
+            price: None,
+            matchno: 7,
+            cross_price: None,
+            cross_type: None,
+        };
+        let csv = serialize_trade_message_to_csv(&msg);
+        assert_eq!(csv, "2024-01-15,123,B,,,,,,7,,\n");
     }
 }
 

--- a/src/message/broken_trade.rs
+++ b/src/message/broken_trade.rs
@@ -3,7 +3,7 @@ use std::io::{Read, Result, Seek, SeekFrom};
 use getset::Getters;
 
 use super::{
-    read_kind, read_matchno, read_nanoseconds, Context, IntoTradeMessage, ReadMessage, Side,
+    read_kind, read_matchno, read_nanoseconds, Context, IntoTradeMessage, ReadMessage,
     TradeMessage, Version,
 };
 
@@ -41,14 +41,14 @@ impl IntoTradeMessage for BrokenTrade {
             date,
             nanoseconds: self.nanoseconds,
             kind: self.kind,
-            refno: 0,               // Broken trades don't have reference numbers
-            side: Side::Buy,        // Broken trades don't have a specific side
-            shares: 0,              // Broken trades don't have shares
-            ticker: "".to_string(), // Broken trades don't specify ticker
-            price: 0,               // Broken trades don't have price
+            refno: None,
+            side: None,
+            shares: None,
+            ticker: None,
+            price: None,
             matchno: self.matchno,
-            cross_price: 0,
-            cross_type: ' ',
+            cross_price: None,
+            cross_type: None,
         }
     }
 }

--- a/src/message/cross_trade.rs
+++ b/src/message/cross_trade.rs
@@ -5,7 +5,7 @@ use getset::Getters;
 
 use super::{
     read_kind, read_matchno, read_nanoseconds, read_price, read_ticker, Context, IntoTradeMessage,
-    ReadMessage, Side, TradeMessage, Version,
+    ReadMessage, TradeMessage, Version,
 };
 
 #[derive(Debug, Getters)]
@@ -54,14 +54,14 @@ impl IntoTradeMessage for CrossTrade {
             date,
             nanoseconds: self.nanoseconds,
             kind: self.kind,
-            refno: 0,        // Cross trades don't have reference numbers
-            side: Side::Buy, // Cross trades don't have a specific side
-            shares: self.shares,
-            ticker: self.ticker,
-            price: self.cross_price,
+            refno: None,
+            side: None,
+            shares: Some(self.shares),
+            ticker: Some(self.ticker),
+            price: None,
             matchno: self.matchno,
-            cross_price: self.cross_price,
-            cross_type: self.cross_type,
+            cross_price: Some(self.cross_price),
+            cross_type: Some(self.cross_type),
         }
     }
 }

--- a/src/message/trade.rs
+++ b/src/message/trade.rs
@@ -56,14 +56,14 @@ impl IntoTradeMessage for Trade {
             date,
             nanoseconds: self.nanoseconds,
             kind: self.kind,
-            refno: self.refno,
-            side: self.side,
-            shares: self.shares as u64,
-            ticker: self.ticker,
-            price: self.price,
+            refno: Some(self.refno),
+            side: Some(self.side),
+            shares: Some(self.shares as u64),
+            ticker: Some(self.ticker),
+            price: Some(self.price),
             matchno: self.matchno,
-            cross_price: 0,  // Not applicable for regular trades
-            cross_type: ' ', // Not applicable for regular trades
+            cross_price: None,
+            cross_type: None,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Replaces sentinel values (`0`, `Side::Buy`, `' '`, `""`) on `TradeMessage` with `Option<...>` for fields that don't apply to a given trade kind.
- Drops the cross-trade `price = cross_price` duplication; cross trades now have `price = None` and consumers can `COALESCE(price, cross_price)` if they want a unified column.
- Adds CSV serialization tests covering all three trade kinds (P / Q / B).

## Why

Sentinels are indistinguishable from real data (`price = 0` is a valid price; `' '` is not a documented cross_type). They will become real nulls when we move to Parquet output (#12), and the model should already encode \"absent\" correctly.

## Field semantics

| field | Trade (P) | CrossTrade (Q) | BrokenTrade (B) |
|---|---|---|---|
| refno | Some | None | None |
| side | Some | None | None |
| shares | Some | Some | None |
| ticker | Some | Some | None |
| price | Some | None | None |
| cross_price | None | Some | None |
| cross_type | None | Some | None |

## Breaking change

CSV consumers parsing the affected columns as `int`/`char` without null handling will break — empty fields now appear where sentinels used to.

## Test plan

- [x] `cargo test` — 65/65 pass (3 new CSV serialization tests).
- [x] `cargo build` — clean.
- [x] `cargo clippy` — clean (pre-commit hook).
- [ ] Eyeball a real CSV output to confirm null fields render as expected before v0.2.0 release.

Closes #11.