### PR TITLE
Per-ticker CSV output, overwrite guard, and lazy order books (#15, #16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ list:
 ```shell
 tvi data/S031413-v41.txt --tickers AAPL,MSFT --depth 3
 ```
+Omitting `--tickers` (or passing `*`) processes every ticker in the file. In that
+case `*` cannot be combined with specific tickers, and output is written to a single
+combined `_all.csv` per collection rather than one file per ticker.
+
+By default `tvi` refuses to overwrite existing output and exits with an error listing
+the conflicting files. Pass `--overwrite` to replace them; overwriting is per-file, so
+`--tickers AAPL --overwrite` replaces only `AAPL`'s files and leaves other tickers intact.
+
 Processing of multiple files (i.e., dates) can be performed using multiple processes or multiple
 jobs on a high-performance computing cluster.
 
@@ -46,20 +54,23 @@ Totalview-ITCH.rs aims to support a variety data storage options. We currently s
 aim to support Parquet and Postgres in the need future.
 
 ### CSV
-The default writer stores data in CSV format. Output has the following directory structure:
+The default writer stores data in CSV format under `./data`, partitioned by
+collection, date, and ticker:
 ```
-test
-|- messages
-   |- date=2013-03-14
-      |- partition.csv
-   |- date=2013-03-15
-      |- partition.csv
-|- orderbooks
+data
+|- orders
+   |- 2013-03-14
+      |- AAPL.csv
+      |- MSFT.csv
+   |- 2013-03-15
+      |- AAPL.csv
+|- books
 |- noii
 |- trades
 ```
-This structure is convenient for parallelizing analyses performed at the
-ticker-date level. 
+Each file holds one ticker for one date. When all tickers are processed (`*`), each
+collection's date directory holds a single combined `_all.csv` instead. This structure
+is convenient for parallelizing analyses performed at the ticker-date level.
 
 ### Postgres
 Under construction 🚧
@@ -70,8 +81,8 @@ Under construction 🚧
 ## Data
 The default parsing method creates four tables/collections:
 
-- `messages`: messages that reflect order book updates,
-- `orderbooks`: order book snapshots following each message, 
+- `orders`: messages that reflect order book updates,
+- `books`: order book snapshots following each message, 
 - `noii`: net order imbalance indicator messages, 
 - `trades`: messages that indicate trades involving non-displayed orders, 
 
@@ -117,7 +128,7 @@ Each row the `orderbooks` table represents a snapshot of the order book associat
 | ask_shares_`n` | `u32`     | The offer volume at the `n`-th best ask (`N=1,..., N`).         | ✓           | `None`    |
 
 ### `noii`
-Net Order Imbalance Indicator (NOII) messages are disseminated prior to market open and close as well as during quote only periods. The `noii` collection stores these messages for all tickers in a single file for each date.
+Net Order Imbalance Indicator (NOII) messages are disseminated prior to market open and close as well as during quote only periods. The `noii` collection stores these messages per ticker and date, following the same layout as the other collections.
 
 | Field             | Type     | Description                                                     | Required? | Default   |
 | ----------------- | -------- | --------------------------------------------------------------- | :-------: | :-------: |

--- a/src/main.rs
+++ b/src/main.rs
@@ -253,17 +253,9 @@ fn main() {
     // Set up metrics
     let mut metrics = PerformanceMetrics::new(filesize);
 
-    // Create order books for each ticker
+    // Order books are created lazily on first message for each ticker, so a `*`
+    // run produces books for every ticker rather than none (#16).
     let mut order_books: HashMap<String, OrderBook> = HashMap::new();
-    for ticker in &tickers {
-        if ticker != "*" {
-            // Skip wildcard
-            order_books.insert(
-                ticker.clone(),
-                OrderBook::new(date.clone(), ticker.clone(), args.depth),
-            );
-        }
-    }
 
     // Begin main loop...
     loop {
@@ -281,7 +273,12 @@ fn main() {
                     Message::AddOrder(data) => {
                         metrics.messages.orders += 1;
                         // Update order book
-                        if let Some(order_book) = order_books.get_mut(data.ticker()) {
+                        {
+                            let order_book = order_books
+                                .entry(data.ticker().to_string())
+                                .or_insert_with(|| {
+                                    OrderBook::new(date.clone(), data.ticker().clone(), args.depth)
+                                });
                             let order_book_start = Instant::now();
                             order_book.add_order(
                                 *data.side(),
@@ -306,7 +303,12 @@ fn main() {
                     Message::CancelOrder(data) => {
                         metrics.messages.orders += 1;
                         // Update order book
-                        if let Some(order_book) = order_books.get_mut(data.ticker()) {
+                        {
+                            let order_book = order_books
+                                .entry(data.ticker().to_string())
+                                .or_insert_with(|| {
+                                    OrderBook::new(date.clone(), data.ticker().clone(), args.depth)
+                                });
                             let order_book_start = Instant::now();
                             if let Err(e) = order_book.remove_order(
                                 *data.side(),
@@ -334,7 +336,12 @@ fn main() {
                     Message::DeleteOrder(data) => {
                         metrics.messages.orders += 1;
                         // Update order book
-                        if let Some(order_book) = order_books.get_mut(data.ticker()) {
+                        {
+                            let order_book = order_books
+                                .entry(data.ticker().to_string())
+                                .or_insert_with(|| {
+                                    OrderBook::new(date.clone(), data.ticker().clone(), args.depth)
+                                });
                             let order_book_start = Instant::now();
                             if let Err(e) = order_book.remove_order(
                                 *data.side(),
@@ -362,7 +369,12 @@ fn main() {
                     Message::ExecuteOrder(data) => {
                         metrics.messages.orders += 1;
                         // Update order book
-                        if let Some(order_book) = order_books.get_mut(data.ticker()) {
+                        {
+                            let order_book = order_books
+                                .entry(data.ticker().to_string())
+                                .or_insert_with(|| {
+                                    OrderBook::new(date.clone(), data.ticker().clone(), args.depth)
+                                });
                             let order_book_start = Instant::now();
                             if let Err(e) = order_book.execute_order(
                                 *data.side(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,12 +9,16 @@ use std::{
 use clap::Parser;
 use indicatif::{ProgressBar, ProgressStyle};
 use tvi::{
+    constants::EVERY_TICKER,
     message::{IntoNOIIMessage, IntoOrderMessage, IntoTradeMessage},
     Buffer, Message, OrderBook, Reader, Version, Writer, CSV,
 };
 
 // TODO: Print error to std:err
 // TODO: handle panics
+
+const MAX_BUFFERED_FACTOR: usize = 64;
+const MIN_FLUSH_DIVISOR: usize = 4;
 
 struct PerformanceMetrics {
     file_size: u64,
@@ -135,9 +139,16 @@ struct Cli {
         short,
         long,
         default_value_t = 1028,
-        help = "The size of internal buffer used for writing data."
+        help = "The per-ticker buffer size (messages) before a ticker is flushed."
     )]
     capacity: usize,
+
+    #[arg(
+        short,
+        long,
+        help = "Overwrite existing output files instead of erroring on collision."
+    )]
+    overwrite: bool,
 }
 
 fn parse_filename<P: AsRef<Path>>(path: P) -> Option<(String, Version)> {
@@ -184,11 +195,49 @@ fn main() {
         "The filename should match the format 'SMMDDYY-vNN' where 'NN' is one of '41' or '50'.",
     );
 
-    // Set up reader and writer
+    // `*` means "all tickers" and subsumes any specific ticker, so combining the
+    // two is incoherent. Reject it rather than silently treating it as plain `*`.
+    if tickers.contains(EVERY_TICKER) && tickers.len() > 1 {
+        eprintln!("Error: '*' (all tickers) cannot be combined with specific tickers.");
+        std::process::exit(1);
+    }
+
+    // Set up reader and writer. Under `*`, output collapses into a single combined
+    // `_all.csv` per collection rather than one file per ticker. The check above
+    // guarantees wildcard implies the ticker set is exactly {"*"}.
+    let wildcard = tickers.contains(EVERY_TICKER);
     let mut buffer = Buffer::new(&args.path).unwrap();
     let mut reader = Reader::new(version, tickers.clone());
-    let backend = CSV::new("data").unwrap();
-    let mut writer = Writer::new(backend, args.capacity);
+    let backend = CSV::new("data", wildcard).unwrap();
+
+    // Refuse to clobber existing output unless --overwrite is set. The resolved
+    // ticker list is known up front; under `*` the guard checks the combined
+    // `_all.csv` files. On overwrite, delete the collisions before parsing so
+    // the append-mode flushes start from a clean file.
+    let mut ticker_list: Vec<String> = tickers.iter().cloned().collect();
+    ticker_list.sort();
+    let collisions = backend.check_collisions(&date, &ticker_list);
+    if !collisions.is_empty() {
+        if !args.overwrite {
+            eprintln!("Refusing to overwrite existing output (pass --overwrite to replace):");
+            for path in &collisions {
+                eprintln!("  {}", path.display());
+            }
+            std::process::exit(1);
+        }
+        backend
+            .clear_collisions(&collisions)
+            .expect("Failed to clear existing output files.");
+    }
+    let max_buffered = args.capacity * MAX_BUFFERED_FACTOR;
+    let min_flush_size = args.capacity / MIN_FLUSH_DIVISOR;
+    let mut writer = Writer::new(
+        backend,
+        args.capacity,
+        max_buffered,
+        min_flush_size,
+        wildcard,
+    );
 
     // Set up progress bar
     let filesize = fs::metadata(&args.path).unwrap().len();

--- a/src/main.rs
+++ b/src/main.rs
@@ -267,7 +267,7 @@ fn main() {
             Ok(msg) => {
                 metrics.messages.total += 1;
                 metrics.duration.parsing += parse_start.elapsed();
-                pb.set_message(format!("{} messages", &metrics.messages.total));
+                pb.set_message(format!("{} messages", metrics.messages.total));
 
                 match msg {
                     Message::AddOrder(data) => {
@@ -442,7 +442,7 @@ fn main() {
     }
 
     metrics.duration.total += start.elapsed();
-    pb.finish_with_message(format!("✅ Processed {} messages", &metrics.messages.total));
+    pb.finish_with_message(format!("✅ Processed {} messages", metrics.messages.total));
     metrics.summarize();
 }
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -241,6 +241,7 @@ pub struct OrderMessage {
     date: String,
     nanoseconds: u64,
     kind: char,
+    #[getset(get = "pub")]
     ticker: String,
     side: Side,
     price: u32,

--- a/src/orderbook.rs
+++ b/src/orderbook.rs
@@ -3,13 +3,17 @@ use std::{
     io::{Error, ErrorKind, Result},
 };
 
+use getset::Getters;
+
 use serde::Serialize;
 
 use crate::message::Side;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Getters, Serialize)]
 pub struct OrderBookSnapshot {
+    #[getset(get = "pub")]
     pub date: String,
+    #[getset(get = "pub")]
     pub ticker: String,
     pub timestamp: u64,
     pub data: Vec<i64>, /* [bid_price_1, bid_size_1, bid_price_2, bid_size_2, ..., ask_price_1,
@@ -65,7 +69,7 @@ impl OrderBook {
         let take = n.min(bids.len());
         bids.select_nth_unstable_by(take.saturating_sub(1), |a, b| b.0.cmp(&a.0));
         bids.truncate(take);
-        bids.sort_unstable_by(|a, b| b.0.cmp(&a.0));
+        bids.sort_unstable_by_key(|b| std::cmp::Reverse(b.0));
         bids
     }
 
@@ -85,7 +89,7 @@ impl OrderBook {
         let take = n.min(asks.len());
         asks.select_nth_unstable_by(take.saturating_sub(1), |a, b| a.0.cmp(&b.0));
         asks.truncate(take);
-        asks.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+        asks.sort_unstable_by_key(|a| a.0);
         asks
     }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -129,7 +129,7 @@ impl<T: Flush> Writer<T> {
     }
 
     fn prune_order_messages(&mut self, threshold: usize) -> Result<(), Box<dyn Error>> {
-        for (_, vec) in self.order_messages.iter_mut() {
+        for vec in self.order_messages.values_mut() {
             if vec.len() >= threshold {
                 let n = vec.len();
                 self.backend.flush_order_messages(vec)?;
@@ -172,7 +172,7 @@ impl<T: Flush> Writer<T> {
     }
 
     fn prune_snapshots(&mut self, threshold: usize) -> Result<(), Box<dyn Error>> {
-        for (_, vec) in self.snapshots.iter_mut() {
+        for vec in self.snapshots.values_mut() {
             if vec.len() >= threshold {
                 let n = vec.len();
                 self.backend.flush_snapshots(vec)?;
@@ -219,7 +219,7 @@ impl<T: Flush> Writer<T> {
     }
 
     fn prune_trade_messages(&mut self, threshold: usize) -> Result<(), Box<dyn Error>> {
-        for (_, vec) in self.trade_messages.iter_mut() {
+        for vec in self.trade_messages.values_mut() {
             if vec.len() >= threshold {
                 let n = vec.len();
                 self.backend.flush_trade_messages(vec)?;
@@ -262,7 +262,7 @@ impl<T: Flush> Writer<T> {
     }
 
     fn prune_noii_messages(&mut self, threshold: usize) -> Result<(), Box<dyn Error>> {
-        for (_, vec) in self.noii_messages.iter_mut() {
+        for vec in self.noii_messages.values_mut() {
             if vec.len() >= threshold {
                 let n = vec.len();
                 self.backend.flush_noii_messages(vec)?;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -39,6 +39,9 @@ pub struct Writer<T: Flush> {
 /// Buffer key and filename stem for the combined output under the `*` wildcard.
 pub(crate) const ALL_STEM: &str = "_all";
 
+/// Stem for trades with no ticker (broken trades).
+pub(crate) const UNKNOWN_STEM: &str = "_unknown";
+
 impl<T: Flush> Writer<T> {
     pub fn new(
         backend: T,
@@ -185,7 +188,8 @@ impl<T: Flush> Writer<T> {
         &mut self,
         trade_message: TradeMessage,
     ) -> Result<(), Box<dyn Error>> {
-        let key = self.bucket_key(trade_message.ticker());
+        let ticker = trade_message.ticker().as_deref().unwrap_or(UNKNOWN_STEM);
+        let key = self.bucket_key(ticker);
         let messages = self.trade_messages.entry(key).or_default();
 
         // Push order message

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,5 +1,6 @@
 mod csv;
 
+use std::collections::HashMap;
 use std::error::Error;
 
 pub use csv::CSV;
@@ -18,22 +19,76 @@ pub trait Flush {
 
 pub struct Writer<T: Flush> {
     backend: T,
-    order_messages: Vec<OrderMessage>,
-    snapshots: Vec<OrderBookSnapshot>,
-    trade_messages: Vec<TradeMessage>,
-    noii_messages: Vec<NOIIMessage>,
+    order_messages: HashMap<String, Vec<OrderMessage>>,
+    order_buffered: usize,
+    snapshots: HashMap<String, Vec<OrderBookSnapshot>>,
+    snapshots_buffered: usize,
+    trade_messages: HashMap<String, Vec<TradeMessage>>,
+    trade_buffered: usize,
+    noii_messages: HashMap<String, Vec<NOIIMessage>>,
+    noii_buffered: usize,
     buffer_size: usize,
+    max_buffered: usize,
+    min_flush_size: usize,
+    /// When set, all messages bucket under a single `_all` key instead of one
+    /// vec per ticker (the `--tickers *` case). Keeps the wildcard run from
+    /// fragmenting memory across thousands of per-ticker vecs.
+    wildcard: bool,
 }
 
+/// Buffer key and filename stem for the combined output under the `*` wildcard.
+pub(crate) const ALL_STEM: &str = "_all";
+
 impl<T: Flush> Writer<T> {
-    pub fn new(backend: T, buffer_size: usize) -> Self {
+    pub fn new(
+        backend: T,
+        buffer_size: usize,
+        max_buffered: usize,
+        min_flush_size: usize,
+        wildcard: bool,
+    ) -> Self {
+        assert!(
+            min_flush_size < buffer_size,
+            "min_flush_size ({}) should be < buffer_size ({})",
+            min_flush_size,
+            buffer_size
+        );
+        assert!(
+            buffer_size <= max_buffered,
+            "buffer_size ({}) should be <= max_buffered ({})",
+            buffer_size,
+            max_buffered
+        );
+
+        let order_messages = HashMap::new();
+        let snapshots = HashMap::new();
+        let trade_messages = HashMap::new();
+        let noii_messages = HashMap::new();
+
         Self {
             backend,
-            order_messages: vec![],
-            snapshots: vec![],
-            trade_messages: vec![],
-            noii_messages: vec![],
+            order_messages,
+            order_buffered: 0,
+            snapshots,
+            snapshots_buffered: 0,
+            trade_messages,
+            trade_buffered: 0,
+            noii_messages,
+            noii_buffered: 0,
             buffer_size,
+            max_buffered,
+            min_flush_size,
+            wildcard,
+        }
+    }
+
+    /// The buffer key for a message's ticker: `_all` under the wildcard,
+    /// otherwise the ticker itself.
+    fn bucket_key(&self, ticker: &str) -> String {
+        if self.wildcard {
+            ALL_STEM.to_string()
+        } else {
+            ticker.to_string()
         }
     }
 
@@ -41,22 +96,86 @@ impl<T: Flush> Writer<T> {
         &mut self,
         order_message: OrderMessage,
     ) -> Result<(), Box<dyn Error>> {
-        self.order_messages.push(order_message);
+        let key = self.bucket_key(order_message.ticker());
+        let messages = self.order_messages.entry(key).or_default();
 
-        if self.order_messages.len() >= self.buffer_size {
-            self.backend.flush_order_messages(&self.order_messages)?;
-            self.order_messages.clear();
+        // Push order message
+        messages.push(order_message);
+        self.order_buffered += 1;
+
+        // Clean up messages
+        if messages.len() >= self.buffer_size {
+            // This ticker has too many messages => flush it
+            let n = messages.len();
+            self.backend.flush_order_messages(messages)?;
+            self.order_buffered -= n;
+            messages.clear();
+        }
+
+        if self.order_buffered > self.max_buffered {
+            // We have too many messages overall => let's clean up a bit
+            self.prune_order_messages(self.min_flush_size)?;
+        }
+
+        if self.order_buffered > self.max_buffered {
+            // We have too many messages overall => let's clean up a bit
+            self.prune_order_messages(0)?;
+        }
+
+        Ok(())
+    }
+
+    fn prune_order_messages(&mut self, threshold: usize) -> Result<(), Box<dyn Error>> {
+        for (_, vec) in self.order_messages.iter_mut() {
+            if vec.len() >= threshold {
+                let n = vec.len();
+                self.backend.flush_order_messages(vec)?;
+                self.order_buffered -= n;
+                vec.clear();
+            }
         }
 
         Ok(())
     }
 
     pub fn write_snapshot(&mut self, snapshot: OrderBookSnapshot) -> Result<(), Box<dyn Error>> {
-        self.snapshots.push(snapshot);
+        let key = self.bucket_key(snapshot.ticker());
+        let snapshots = self.snapshots.entry(key).or_default();
 
-        if self.snapshots.len() >= self.buffer_size {
-            self.backend.flush_snapshots(&self.snapshots)?;
-            self.snapshots.clear();
+        // Push snapshot
+        snapshots.push(snapshot);
+        self.snapshots_buffered += 1;
+
+        // Clean up snapshots
+        if snapshots.len() >= self.buffer_size {
+            // This ticker has too many snapshots => flush it
+            let n = snapshots.len();
+            self.backend.flush_snapshots(snapshots)?;
+            self.snapshots_buffered -= n;
+            snapshots.clear();
+        }
+
+        if self.snapshots_buffered > self.max_buffered {
+            // We have too many snapshots overall => let's clean up a bit
+            self.prune_snapshots(self.min_flush_size)?;
+        }
+
+        if self.snapshots_buffered > self.max_buffered {
+            // We have too many snapshots overall => let's clean up a bit
+            self.prune_snapshots(0)?;
+        }
+
+        Ok(())
+    }
+
+    fn prune_snapshots(&mut self, threshold: usize) -> Result<(), Box<dyn Error>> {
+        for (_, vec) in self.snapshots.iter_mut() {
+            if vec.len() >= threshold {
+                let n = vec.len();
+                self.backend.flush_snapshots(vec)?;
+                self.snapshots_buffered -= n;
+                vec.clear();
+            }
         }
 
         Ok(())
@@ -66,22 +185,86 @@ impl<T: Flush> Writer<T> {
         &mut self,
         trade_message: TradeMessage,
     ) -> Result<(), Box<dyn Error>> {
-        self.trade_messages.push(trade_message);
+        let key = self.bucket_key(trade_message.ticker());
+        let messages = self.trade_messages.entry(key).or_default();
 
-        if self.trade_messages.len() >= self.buffer_size {
-            self.backend.flush_trade_messages(&self.trade_messages)?;
-            self.trade_messages.clear();
+        // Push order message
+        messages.push(trade_message);
+        self.trade_buffered += 1;
+
+        // Clean up messages
+        if messages.len() >= self.buffer_size {
+            // This ticker has too many messages => flush it
+            let n = messages.len();
+            self.backend.flush_trade_messages(messages)?;
+            self.trade_buffered -= n;
+            messages.clear();
+        }
+
+        if self.trade_buffered > self.max_buffered {
+            // We have too many messages overall => let's clean up a bit
+            self.prune_trade_messages(self.min_flush_size)?;
+        }
+
+        if self.trade_buffered > self.max_buffered {
+            // We have too many messages overall => let's clean up a bit
+            self.prune_trade_messages(0)?;
+        }
+
+        Ok(())
+    }
+
+    fn prune_trade_messages(&mut self, threshold: usize) -> Result<(), Box<dyn Error>> {
+        for (_, vec) in self.trade_messages.iter_mut() {
+            if vec.len() >= threshold {
+                let n = vec.len();
+                self.backend.flush_trade_messages(vec)?;
+                self.trade_buffered -= n;
+                vec.clear();
+            }
         }
 
         Ok(())
     }
 
     pub fn write_noii_message(&mut self, noii_message: NOIIMessage) -> Result<(), Box<dyn Error>> {
-        self.noii_messages.push(noii_message);
+        let key = self.bucket_key(noii_message.ticker());
+        let messages = self.noii_messages.entry(key).or_default();
 
-        if self.noii_messages.len() >= self.buffer_size {
-            self.backend.flush_noii_messages(&self.noii_messages)?;
-            self.noii_messages.clear();
+        // Push NOII message
+        messages.push(noii_message);
+        self.noii_buffered += 1;
+
+        // Clean up messages
+        if messages.len() >= self.buffer_size {
+            // This ticker has too many messages => flush it
+            let n = messages.len();
+            self.backend.flush_noii_messages(messages)?;
+            self.noii_buffered -= n;
+            messages.clear();
+        }
+
+        if self.noii_buffered > self.max_buffered {
+            // We have too many messages overall => let's clean up a bit
+            self.prune_noii_messages(self.min_flush_size)?;
+        }
+
+        if self.noii_buffered > self.max_buffered {
+            // We have too many messages overall => let's clean up a bit
+            self.prune_noii_messages(0)?;
+        }
+
+        Ok(())
+    }
+
+    fn prune_noii_messages(&mut self, threshold: usize) -> Result<(), Box<dyn Error>> {
+        for (_, vec) in self.noii_messages.iter_mut() {
+            if vec.len() >= threshold {
+                let n = vec.len();
+                self.backend.flush_noii_messages(vec)?;
+                self.noii_buffered -= n;
+                vec.clear();
+            }
         }
 
         Ok(())
@@ -90,31 +273,27 @@ impl<T: Flush> Writer<T> {
 
 impl<T: Flush> Drop for Writer<T> {
     fn drop(&mut self) {
-        if !self.order_messages.is_empty() {
-            match self.backend.flush_order_messages(&self.order_messages) {
-                Err(e) => eprintln!("Failed to flush residual order messages: {}", e),
-                Ok(_) => self.order_messages.clear(),
+        if self.order_buffered > 0 {
+            if let Err(e) = self.prune_order_messages(0) {
+                eprintln!("Failed to flush residual order messages: {}", e);
             };
         }
 
-        if !self.snapshots.is_empty() {
-            match self.backend.flush_snapshots(&self.snapshots) {
-                Err(e) => eprintln!("Failed to flush residual snapshots: {}", e),
-                Ok(_) => self.snapshots.clear(),
+        if self.snapshots_buffered > 0 {
+            if let Err(e) = self.prune_snapshots(0) {
+                eprintln!("Failed to flush residual snapshots: {}", e);
             };
         }
 
-        if !self.trade_messages.is_empty() {
-            match self.backend.flush_trade_messages(&self.trade_messages) {
-                Err(e) => eprintln!("Failed to flush residual trade messages: {}", e),
-                Ok(_) => self.trade_messages.clear(),
+        if self.trade_buffered > 0 {
+            if let Err(e) = self.prune_trade_messages(0) {
+                eprintln!("Failed to flush residual trade messages: {}", e);
             };
         }
 
-        if !self.noii_messages.is_empty() {
-            match self.backend.flush_noii_messages(&self.noii_messages) {
-                Err(e) => eprintln!("Failed to flush residual noii messages: {}", e),
-                Ok(_) => self.noii_messages.clear(),
+        if self.noii_buffered > 0 {
+            if let Err(e) = self.prune_noii_messages(0) {
+                eprintln!("Failed to flush residual NOII messages: {}", e);
             };
         }
     }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -121,7 +121,7 @@ impl<T: Flush> Writer<T> {
         }
 
         if self.order_buffered > self.max_buffered {
-            // We have too many messages overall => let's clean up a bit
+            // We still have too many messages overall => flush everything
             self.prune_order_messages(0)?;
         }
 
@@ -164,7 +164,7 @@ impl<T: Flush> Writer<T> {
         }
 
         if self.snapshots_buffered > self.max_buffered {
-            // We have too many snapshots overall => let's clean up a bit
+            // We still have too many snapshots overall => flush everything
             self.prune_snapshots(0)?;
         }
 
@@ -211,7 +211,7 @@ impl<T: Flush> Writer<T> {
         }
 
         if self.trade_buffered > self.max_buffered {
-            // We have too many messages overall => let's clean up a bit
+            // We still have too many messages overall => flush everything
             self.prune_trade_messages(0)?;
         }
 
@@ -254,7 +254,7 @@ impl<T: Flush> Writer<T> {
         }
 
         if self.noii_buffered > self.max_buffered {
-            // We have too many messages overall => let's clean up a bit
+            // We still have too many messages overall => flush everything
             self.prune_noii_messages(0)?;
         }
 

--- a/src/writer/csv.rs
+++ b/src/writer/csv.rs
@@ -327,7 +327,78 @@ mod tests {
         );
     }
 
-    // NOTE: check_collisions / existing_csvs are filesystem-dependent (the
-    // partition-level wildcard vs per-ticker conflict rule). Covering them
-    // properly needs a tempdir fixture; tracked as a follow-up.
+    // --- Collision guard (filesystem-backed via tempdir) ---
+
+    use tempfile::TempDir;
+
+    const DATE: &str = "2017-02-27";
+
+    /// A CSV backend rooted at a fresh tempdir. The dir is removed when the
+    /// returned guard drops, so the tempdir must outlive the CSV.
+    fn temp_backend(wildcard: bool) -> (TempDir, CSV) {
+        let tmp = TempDir::new().unwrap();
+        let csv = CSV::new(tmp.path(), wildcard).unwrap();
+        (tmp, csv)
+    }
+
+    /// Create an empty output file for `stem` in `collection` under `date`.
+    fn touch(csv: &CSV, date: &str, stem: &str, collection: Collection) -> PathBuf {
+        let path = csv.path_to(date, stem, collection);
+        create_dir_all(path.parent().unwrap()).unwrap();
+        std::fs::write(&path, "").unwrap();
+        path
+    }
+
+    #[test]
+    fn no_collision_when_partition_empty() {
+        let (_tmp, csv) = temp_backend(false);
+        assert!(csv.check_collisions(DATE, &["AAPL".to_string()]).is_empty());
+    }
+
+    #[test]
+    fn per_ticker_collides_only_with_named_tickers() {
+        let (_tmp, csv) = temp_backend(false);
+        let aapl = touch(&csv, DATE, "AAPL", Collection::Orders);
+        touch(&csv, DATE, "MSFT", Collection::Orders);
+
+        // Checking only AAPL must not flag MSFT — overwrite is surgical.
+        let hits = csv.check_collisions(DATE, &["AAPL".to_string()]);
+        assert_eq!(hits, vec![aapl]);
+    }
+
+    #[test]
+    fn per_ticker_collides_with_existing_all_file() {
+        // A per-ticker run into a partition already written by a wildcard run.
+        let (_tmp, csv) = temp_backend(false);
+        let all = touch(&csv, DATE, ALL_STEM, Collection::Orders);
+
+        let hits = csv.check_collisions(DATE, &["AAPL".to_string()]);
+        assert!(
+            hits.contains(&all),
+            "per-ticker run must conflict with _all.csv"
+        );
+    }
+
+    #[test]
+    fn wildcard_collides_with_existing_per_ticker_files() {
+        // The original gap: wildcard run into a partition with per-ticker files
+        // but no _all.csv. Must still detect the conflict.
+        let (_tmp, csv) = temp_backend(true);
+        let aapl = touch(&csv, DATE, "AAPL", Collection::Orders);
+        let msft = touch(&csv, DATE, "MSFT", Collection::Orders);
+
+        let hits = csv.check_collisions(DATE, &["*".to_string()]);
+        assert!(hits.contains(&aapl) && hits.contains(&msft));
+    }
+
+    #[test]
+    fn clear_collisions_removes_files() {
+        let (_tmp, csv) = temp_backend(false);
+        let aapl = touch(&csv, DATE, "AAPL", Collection::Orders);
+
+        let hits = csv.check_collisions(DATE, &["AAPL".to_string()]);
+        csv.clear_collisions(&hits).unwrap();
+        assert!(!aapl.exists());
+        assert!(csv.check_collisions(DATE, &["AAPL".to_string()]).is_empty());
+    }
 }

--- a/src/writer/csv.rs
+++ b/src/writer/csv.rs
@@ -1,53 +1,168 @@
 use std::{
     error::Error,
-    fs::{create_dir, create_dir_all, OpenOptions},
+    fs::{create_dir_all, remove_file, File, OpenOptions},
     path::{Path, PathBuf},
 };
 
 use csv::WriterBuilder;
 
-use super::Flush;
+use super::{Flush, ALL_STEM};
 use crate::{
     message::{NOIIMessage, OrderMessage, TradeMessage},
     orderbook::OrderBookSnapshot,
 };
 
+/// The output collections produced by a parse run. Each maps to a top-level
+/// subdirectory under the output dir.
+#[derive(Clone, Copy)]
+pub enum Collection {
+    Orders,
+    Trades,
+    Noii,
+    Books,
+}
+
+impl Collection {
+    fn dir(self) -> &'static str {
+        match self {
+            Collection::Orders => "orders",
+            Collection::Trades => "trades",
+            Collection::Noii => "noii",
+            Collection::Books => "books",
+        }
+    }
+
+    /// All collections, for sweeping every output a ticker may have produced.
+    const ALL: [Collection; 4] = [
+        Collection::Orders,
+        Collection::Trades,
+        Collection::Noii,
+        Collection::Books,
+    ];
+}
+
 pub struct CSV {
     output_dir: PathBuf,
+    /// When set, all messages collapse into a single `_all.csv` per collection
+    /// rather than one file per ticker (the `--tickers *` case).
+    wildcard: bool,
 }
 
 impl CSV {
-    pub fn new<P: AsRef<Path>>(output_dir: P) -> std::io::Result<Self> {
+    pub fn new<P: AsRef<Path>>(output_dir: P, wildcard: bool) -> std::io::Result<Self> {
         let path = output_dir.as_ref().to_path_buf();
         if !path.exists() {
             create_dir_all(&path)?;
         }
 
-        Ok(Self { output_dir: path })
+        Ok(Self {
+            output_dir: path,
+            wildcard,
+        })
+    }
+
+    /// The filename stem for a flush: the message's own ticker, or the combined
+    /// `_all` stem under the wildcard. The one place the collapse is decided.
+    fn file_stem<'a>(&self, ticker: &'a str) -> &'a str {
+        if self.wildcard {
+            ALL_STEM
+        } else {
+            ticker
+        }
+    }
+
+    /// The collection's date directory: `<dir>/<collection>/<date>`.
+    fn date_dir(&self, date: &str, collection: Collection) -> PathBuf {
+        self.output_dir.join(collection.dir()).join(date)
+    }
+
+    /// The single source of truth for output paths:
+    /// `<dir>/<collection>/<date>/<stem>.csv`.
+    fn path_to(&self, date: &str, stem: &str, collection: Collection) -> PathBuf {
+        self.date_dir(date, collection)
+            .join(format!("{}.csv", stem))
+    }
+
+    /// Existing `.csv` files in a collection's date directory.
+    fn existing_csvs(&self, date: &str, collection: Collection) -> Vec<PathBuf> {
+        let dir = self.date_dir(date, collection);
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            return vec![];
+        };
+        entries
+            .flatten()
+            .map(|e| e.path())
+            .filter(|p| p.extension().is_some_and(|ext| ext == "csv"))
+            .collect()
+    }
+
+    /// Existing output files a run would conflict with. Wildcard and per-ticker
+    /// output are mutually exclusive within a partition: a wildcard run conflicts
+    /// with any existing file in the date dir, and a per-ticker run conflicts with
+    /// its own `<ticker>.csv` or an existing `_all.csv`.
+    pub fn check_collisions(&self, date: &str, tickers: &[String]) -> Vec<PathBuf> {
+        let mut collisions = vec![];
+        for collection in Collection::ALL {
+            if self.wildcard {
+                collisions.extend(self.existing_csvs(date, collection));
+            } else {
+                let all = self.path_to(date, ALL_STEM, collection);
+                if all.exists() {
+                    collisions.push(all);
+                }
+                for ticker in tickers {
+                    let path = self.path_to(date, ticker, collection);
+                    if path.exists() {
+                        collisions.push(path);
+                    }
+                }
+            }
+        }
+        collisions
+    }
+
+    /// Delete the given colliding files. Consumes paths produced by
+    /// [`check_collisions`]; does not re-derive them.
+    pub fn clear_collisions(&self, collisions: &[PathBuf]) -> std::io::Result<()> {
+        for path in collisions {
+            remove_file(path)?;
+        }
+        Ok(())
+    }
+
+    /// Open (create-or-append) the file for `ticker` in `collection`, creating
+    /// the collection/date directory tree as needed. Returns the file and
+    /// whether it already existed (so callers can decide whether to write headers).
+    fn open_for(
+        &self,
+        date: &str,
+        ticker: &str,
+        collection: Collection,
+    ) -> std::io::Result<(File, bool)> {
+        let filepath = self.path_to(date, self.file_stem(ticker), collection);
+        if let Some(parent) = filepath.parent() {
+            create_dir_all(parent)?;
+        }
+        let file_exists = filepath.exists();
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(filepath)?;
+        Ok((file, file_exists))
     }
 }
 
 impl Flush for CSV {
     fn flush_order_messages(&self, order_messages: &[OrderMessage]) -> Result<(), Box<dyn Error>> {
-        let dirpath = self.output_dir.join("orders");
-        if !dirpath.exists() {
-            create_dir(&dirpath)?;
-        }
-
         if order_messages.is_empty() {
             return Ok(());
         }
 
-        let date = order_messages[0].date().clone(); // Assume same date across all messages
-        let filename = format!("{}.csv", date);
-        let filepath = dirpath.join(filename);
-        let file_exists = filepath.exists();
+        // Assume same date and ticker across all messages (one ticker per flush).
+        let date = order_messages[0].date();
+        let ticker = order_messages[0].ticker();
 
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(filepath)?;
-
+        let (file, file_exists) = self.open_for(date, ticker, Collection::Orders)?;
         let mut writer = WriterBuilder::new()
             .has_headers(!file_exists)
             .from_writer(file);
@@ -62,79 +177,61 @@ impl Flush for CSV {
     }
 
     fn flush_snapshots(&self, snapshots: &[OrderBookSnapshot]) -> Result<(), Box<dyn Error>> {
-        let dirpath = self.output_dir.join("books");
-        if !dirpath.exists() {
-            create_dir(&dirpath)?;
+        if snapshots.is_empty() {
+            return Ok(());
         }
 
-        let date = snapshots[0].date.clone(); // Assume same date across all messages
-        let filename = format!("{}.csv", date);
-        let filepath = dirpath.join(filename);
-        let file_exists = filepath.exists();
+        // Assume same date and ticker across all snapshots (one ticker per flush).
+        let date = snapshots[0].date();
+        let ticker = snapshots[0].ticker();
 
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(filepath)?;
-
+        let (file, file_exists) = self.open_for(date, ticker, Collection::Books)?;
         let mut writer = WriterBuilder::new()
             .has_headers(false) // We'll write headers manually
             .from_writer(file);
 
-        if !snapshots.is_empty() {
-            // Write headers if file is new
-            if !file_exists {
-                let levels_count = snapshots[0].data.len() / 4; // levels per side
-                let mut headers = vec!["ticker".to_string(), "timestamp".to_string()];
+        // Write headers if file is new
+        if !file_exists {
+            let levels_count = snapshots[0].data.len() / 4; // levels per side
+            let mut headers = vec!["ticker".to_string(), "timestamp".to_string()];
 
-                for i in 1..=levels_count {
-                    headers.push(format!("bid_price_{}", i));
-                    headers.push(format!("bid_size_{}", i));
-                }
-
-                for i in 1..=levels_count {
-                    headers.push(format!("ask_price_{}", i));
-                    headers.push(format!("ask_size_{}", i));
-                }
-
-                writer.write_record(&headers)?;
+            for i in 1..=levels_count {
+                headers.push(format!("bid_price_{}", i));
+                headers.push(format!("bid_size_{}", i));
             }
 
-            // Write data rows
-            for snapshot in snapshots {
-                let mut record = vec![snapshot.ticker.clone(), snapshot.timestamp.to_string()];
-                for val in &snapshot.data {
-                    record.push(val.to_string());
-                }
-                writer.write_record(&record)?;
+            for i in 1..=levels_count {
+                headers.push(format!("ask_price_{}", i));
+                headers.push(format!("ask_size_{}", i));
             }
 
-            writer.flush()?;
+            writer.write_record(&headers)?;
         }
+
+        // Write data rows
+        for snapshot in snapshots {
+            let mut record = vec![snapshot.ticker.clone(), snapshot.timestamp.to_string()];
+            for val in &snapshot.data {
+                record.push(val.to_string());
+            }
+            writer.write_record(&record)?;
+        }
+
+        writer.flush()?;
 
         Ok(())
     }
 
     fn flush_trade_messages(&self, trade_messages: &[TradeMessage]) -> Result<(), Box<dyn Error>> {
-        let dirpath = self.output_dir.join("trades");
-        if !dirpath.exists() {
-            create_dir(&dirpath)?;
-        }
-
         if trade_messages.is_empty() {
             return Ok(());
         }
 
-        let date = trade_messages[0].date().clone(); // Assume same date across all messages
-        let filename = format!("{}.csv", date);
-        let filepath = dirpath.join(filename);
-        let file_exists = filepath.exists();
+        // Assume same date and ticker across all messages (one ticker per flush).
+        let date = trade_messages[0].date();
+        let ticker = trade_messages[0].ticker();
 
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(filepath)?;
-
+        let (file, file_exists) = self.open_for(date, ticker, Collection::Trades)?;
         let mut writer = WriterBuilder::new()
             .has_headers(!file_exists)
             .from_writer(file);
@@ -149,25 +246,15 @@ impl Flush for CSV {
     }
 
     fn flush_noii_messages(&self, noii_messages: &[NOIIMessage]) -> Result<(), Box<dyn Error>> {
-        let dirpath = self.output_dir.join("noii");
-        if !dirpath.exists() {
-            create_dir(&dirpath)?;
-        }
-
         if noii_messages.is_empty() {
             return Ok(());
         }
 
-        let date = noii_messages[0].date().clone(); // Assume same date across all messages
-        let filename = format!("{}.csv", date);
-        let filepath = dirpath.join(filename);
-        let file_exists = filepath.exists();
+        // Assume same date and ticker across all messages (one ticker per flush).
+        let date = noii_messages[0].date();
+        let ticker = noii_messages[0].ticker();
 
-        let file = OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(filepath)?;
-
+        let (file, file_exists) = self.open_for(date, ticker, Collection::Noii)?;
         let mut writer = WriterBuilder::new()
             .has_headers(!file_exists)
             .from_writer(file);
@@ -180,4 +267,67 @@ impl Flush for CSV {
 
         Ok(())
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn backend(wildcard: bool) -> CSV {
+        // Construct directly to avoid touching the filesystem in CSV::new.
+        CSV {
+            output_dir: PathBuf::from("data"),
+            wildcard,
+        }
+    }
+
+    #[test]
+    fn path_uses_ticker_when_not_wildcard() {
+        let csv = backend(false);
+        assert_eq!(
+            csv.path_to("2017-02-27", csv.file_stem("AAPL"), Collection::Orders),
+            PathBuf::from("data/orders/2017-02-27/AAPL.csv")
+        );
+    }
+
+    #[test]
+    fn path_collapses_to_all_when_wildcard() {
+        let csv = backend(true);
+        // Even given a real ticker, the stem collapses to `_all`.
+        assert_eq!(
+            csv.path_to("2017-02-27", csv.file_stem("AAPL"), Collection::Trades),
+            PathBuf::from("data/trades/2017-02-27/_all.csv")
+        );
+    }
+
+    #[test]
+    fn each_collection_maps_to_its_own_dir() {
+        let csv = backend(false);
+        let p = |c| csv.path_to("d", "T", c);
+        assert_eq!(p(Collection::Orders), PathBuf::from("data/orders/d/T.csv"));
+        assert_eq!(p(Collection::Trades), PathBuf::from("data/trades/d/T.csv"));
+        assert_eq!(p(Collection::Noii), PathBuf::from("data/noii/d/T.csv"));
+        assert_eq!(p(Collection::Books), PathBuf::from("data/books/d/T.csv"));
+    }
+
+    #[test]
+    fn wildcard_path_stem_is_all_not_literal_star() {
+        // Under wildcard a flush writes `_all.csv`, never a file named `*`.
+        let csv = backend(true);
+        let path = csv.path_to("d", csv.file_stem("*"), Collection::Orders);
+        assert_eq!(path, PathBuf::from("data/orders/d/_all.csv"));
+    }
+
+    #[test]
+    fn date_dir_nests_collection_and_date() {
+        let csv = backend(false);
+        assert_eq!(
+            csv.date_dir("2017-02-27", Collection::Books),
+            PathBuf::from("data/books/2017-02-27")
+        );
+    }
+
+    // NOTE: check_collisions / existing_csvs are filesystem-dependent (the
+    // partition-level wildcard vs per-ticker conflict rule). Covering them
+    // properly needs a tempdir fixture; tracked as a follow-up.
 }

--- a/src/writer/csv.rs
+++ b/src/writer/csv.rs
@@ -6,7 +6,7 @@ use std::{
 
 use csv::WriterBuilder;
 
-use super::{Flush, ALL_STEM};
+use super::{Flush, ALL_STEM, UNKNOWN_STEM};
 use crate::{
     message::{NOIIMessage, OrderMessage, TradeMessage},
     orderbook::OrderBookSnapshot,
@@ -228,8 +228,12 @@ impl Flush for CSV {
         }
 
         // Assume same date and ticker across all messages (one ticker per flush).
+        // Broken trades carry no ticker; they file under `_unknown`.
         let date = trade_messages[0].date();
-        let ticker = trade_messages[0].ticker();
+        let ticker = trade_messages[0]
+            .ticker()
+            .as_deref()
+            .unwrap_or(UNKNOWN_STEM);
 
         let (file, file_exists) = self.open_for(date, ticker, Collection::Trades)?;
         let mut writer = WriterBuilder::new()


### PR DESCRIPTION
Implements #15 and fixes #16.

## #15 — Per-ticker CSV output with overwrite guard

Replaces the flat, append-accumulating `{date}.csv` writer with a per-ticker layout: `data/{collection}/{date}/{ticker}.csv`.

- **Per-ticker buffering** with a three-tier eviction sweep (per-ticker flush at `buffer_size`, aggregate prune at `min_flush_size`, then flush-all) to bound memory under wide ticker fan-out.
- **Overwrite guard**: parse refuses to clobber existing output and exits non-zero unless `--overwrite` is passed, which deletes the conflicting files first. Overwrite is per-file (surgical).
- **Partition-level conflict rule**: wildcard (`_all.csv`) and per-ticker output are mutually exclusive within a date partition. A `*` run conflicts with any existing file in the partition; a per-ticker run conflicts with an existing `_all.csv`.
- **`*` wildcard** collapses to a single `_all.csv` per collection (both buffering and filenames, via a shared `ALL_STEM`). `*` may not be combined with specific tickers.
- `Writer::new` asserts `min_flush_size < buffer_size <= max_buffered`.
- README updated for the new layout and flags.

## #16 — Lazy order books so `*` produces book output

Order books were created eagerly only for explicitly-named tickers, with `*` skipped — so a `*` run (the default) silently produced empty `books/`. Books are now created lazily via `entry().or_insert_with()` as messages arrive, so every ticker the reader emits gets a book regardless of wildcard mode.

## Testing

- Tempdir-backed tests for the collision guard, including the wildcard-vs-per-ticker partition-rule regression.
- Verified end-to-end on a real ITCH file: per-ticker layout, surgical overwrite, and book output (729k snapshots for AAPL).
- 72 tests pass; fmt + clippy clean.

## Known follow-ups (not in this PR)

- Tempfile tests cover the guard, not the full parse→flush→file pipeline.
- README schema-section headers `### messages`/`### orderbooks` still use pre-rename names.
- The four order-book arms in `main.rs` are now duplicated (refactor candidate, alongside the writer's four `write_`/`prune_` methods).